### PR TITLE
Fix broken rules

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -41,7 +41,7 @@ Metrics/MethodLength:
   Exclude:
     - 'test/**/*'
   Max: 25
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Exclude:
     - 'test/**/*'
     - 'spec/**/*'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -32,9 +32,7 @@ Metrics/ClassLength:
     - 'test/**/*'
   Enabled: true
   Max: 120
-Metrics/LineLength:
-  Max: 100
-Metrics/LineLength:
+Layout/LineLength:
   Include:
     - 'spec/**/*'
     - 'test/**/*'


### PR DESCRIPTION
#### What does this PR do?

Update obsolete configuration that breaks rubocop.

LineLength Max had been set twice, and LineLength should be in the
Layout namespace.
