### PR TITLE
Update for 2.7

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - vendor/**/*
     - node_modules/**/*
     - 'spec/*_helper.rb'
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
 Layout/DotPosition:
   EnforcedStyle: "trailing"
 Lint/AmbiguousBlockAssociation:


### PR DESCRIPTION
#### What does this PR do?

Updates for Ruby 2.7 syntax, linter is flagging stuff that it shouldn't.
